### PR TITLE
Fix drawable touch if the view has a parent view

### DIFF
--- a/library/src/main/java/com/xwray/passwordview/PasswordView.java
+++ b/library/src/main/java/com/xwray/passwordview/PasswordView.java
@@ -80,7 +80,7 @@ public class PasswordView extends EditText {
 
     @Override public boolean onTouchEvent(MotionEvent event) {
         if (event.getAction() == MotionEvent.ACTION_UP
-                && event.getX() >= (getRight() - getCompoundDrawables()[2].getBounds().width())) {
+                && event.getRawX() >= (getRight() - getCompoundDrawables()[2].getBounds().width())) {
             visible = !visible;
             setup();
             invalidate();


### PR DESCRIPTION
I experimented this bug recently. According to [this post](http://stackoverflow.com/questions/3554377/handling-click-events-on-a-drawable-within-an-edittext), `event.getRawX()` has to be used.
