### PR TITLE
Fix click event bug

### DIFF
--- a/library/src/main/java/com/xwray/passwordview/PasswordView.java
+++ b/library/src/main/java/com/xwray/passwordview/PasswordView.java
@@ -80,7 +80,8 @@ public class PasswordView extends EditText {
 
     @Override public boolean onTouchEvent(MotionEvent event) {
         if (event.getAction() == MotionEvent.ACTION_UP
-                && event.getX() >= (getRight() - getCompoundDrawables()[2].getBounds().width())) {
+                && event.getX() >= (getWidth() - getCompoundDrawables()[2].getBounds().width() - getPaddingRight())
+                && event.getX() <= (getWidth() - getPaddingRight())) {
             visible = !visible;
             setup();
             invalidate();


### PR DESCRIPTION
Fix clicked coordinate calculation bug，handle the click event correctly
Considering more about `padding` and PasswordView don't start from the left of parent view~
修复点击坐标的计算，能正确响应点击事件
