### PR TITLE
Don't allow TextView.setError

### DIFF
--- a/library/src/main/java/com/xwray/passwordview/PasswordView.java
+++ b/library/src/main/java/com/xwray/passwordview/PasswordView.java
@@ -148,6 +148,14 @@ public class PasswordView extends AppCompatEditText {
         setTypeface(typeface);
     }
 
+    @Override @public void setError(CharSequence error) {
+        throw new RuntimeException("Please use TextInputLayout.setError() instead!");
+    }
+
+    @Override public void setError(CharSequence error, Drawable icon) {
+        throw new RuntimeException("Please use TextInputLayout.setError() instead!");
+    }
+
     public void setUseStrikeThrough(boolean useStrikeThrough) {
         this.useStrikeThrough = useStrikeThrough;
     }
@@ -155,7 +163,7 @@ public class PasswordView extends AppCompatEditText {
     private static boolean isDark(float[] hsl) {
         return hsl[2] < 0.5f;
     }
-    
+
     public static boolean isDark(@ColorInt int color) {
         float[] hsl = new float[3];
         android.support.v4.graphics.ColorUtils.colorToHSL(color, hsl);


### PR DESCRIPTION
It messes with the right drawable and really doesn't make sense
when TextInputLayout.setError is indicated in the Material design
guidelines instead
